### PR TITLE
ci: deploy Cloudflare after validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -36,3 +36,65 @@ jobs:
           report-path: .nuxt/dx/size-budget.json
           threshold-kb: 10
       - run: pnpm cf:types:check
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: Production
+      url: https://harlanzw.com
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Cache skew protection assets
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: node_modules/.cache/nuxt-seo
+          key: nuxt-skew-production-${{ github.sha }}
+          restore-keys: |
+            nuxt-skew-production-
+      - run: pnpm build
+        timeout-minutes: 10
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      - name: Deploy application Worker
+        run: pnpm exec wrangler deploy --message "$GITHUB_SHA"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Deploy www redirect Worker
+        run: pnpm exec wrangler deploy --config wrangler.www.jsonc --message "$GITHUB_SHA"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Verify deployed versions
+        run: |
+          for worker in harlanzw-com harlanzw-com-www; do
+            for attempt in {1..12}; do
+              deployed_sha=$(pnpm exec wrangler deployments list --name "$worker" --json | jq -r '.[0].annotations["workers/message"]')
+              if [ "$deployed_sha" = "$GITHUB_SHA" ]; then
+                break
+              fi
+              if [ "$attempt" = 12 ]; then
+                echo "$worker deployed $deployed_sha, expected $GITHUB_SHA" >&2
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Smoke production
+        run: |
+          test "$(curl --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 --max-time 15 --output /dev/null --write-out '%{http_code}' https://harlanzw.com/)" = 200
+          test "$(curl --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 --max-time 15 --output /dev/null --write-out '%{http_code} %{redirect_url}' https://www.harlanzw.com/)" = "308 https://harlanzw.com/"


### PR DESCRIPTION
Deploy both Cloudflare Workers after the existing CI validation succeeds on `main`.

The Production job rebuilds the exact commit, records its SHA in both Worker versions, verifies both active deployments, then checks the apex and `www` redirect.

Verification:
- `wrangler deploy --dry-run` for both Workers
- workflow YAML parse

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).