### PR TITLE
fix: verify latest Cloudflare deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           for worker in harlanzw-com harlanzw-com-www; do
             for attempt in {1..12}; do
-              deployed_sha=$(pnpm exec wrangler deployments list --name "$worker" --json | jq -r '.[0].annotations["workers/message"]')
+              deployed_sha=$(pnpm exec wrangler deployments list --name "$worker" --json | jq -r 'sort_by(.created_on) | last | .annotations["workers/message"]')
               if [ "$deployed_sha" = "$GITHUB_SHA" ]; then
                 break
               fi


### PR DESCRIPTION
Wrangler lists deployments from oldest to newest. Sort by `created_on` before checking the deployed commit.

Verification:
- both active Workers report merge `1453c37ade41086e0ae0581acde87a25a8e6e5e9`
- workflow YAML parse

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).