### PR TITLE
chore: fix ci deployment smoke retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,5 +109,14 @@ jobs:
           test "$(curl --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 --max-time 15 --output /dev/null --write-out '%{http_code}' https://harlanzw.com/)" = 200
           test "$(curl --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 --max-time 15 --output /dev/null --write-out '%{http_code} %{redirect_url}' https://www.harlanzw.com/)" = "308 https://harlanzw.com/"
           curl --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 --max-time 15 "https://harlanzw.com/api/sponsors?deployment=$GITHUB_SHA" | jq -e '._tag == "available" and (.sponsors | length > 0)'
-          curl --fail --silent --show-error --retry 12 --retry-all-errors --retry-delay 5 --max-time 15 --output "$RUNNER_TEMP/sponsors.html" "https://harlanzw.com/sponsors?deployment=$GITHUB_SHA"
-          grep -q 'Top sponsors' "$RUNNER_TEMP/sponsors.html"
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --max-time 15 --output "$RUNNER_TEMP/sponsors.html" "https://harlanzw.com/sponsors?deployment=$GITHUB_SHA&attempt=$attempt" \
+              && grep -q 'Top sponsors' "$RUNNER_TEMP/sponsors.html"; then
+              break
+            fi
+            if [ "$attempt" = 12 ]; then
+              echo "Sponsors page did not reach the deployed version" >&2
+              exit 1
+            fi
+            sleep 5
+          done


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #23.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Retry the Sponsors page assertion while the new Worker reaches every edge. The first #23 deployment served the previous page briefly, then passed the same assertion seconds later.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).