### PR TITLE
fix: disable remote font providers

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -126,6 +126,15 @@ export default defineNuxtConfig({
   },
 
   fonts: {
+    providers: {
+      adobe: false,
+      bunny: false,
+      fontshare: false,
+      fontsource: false,
+      google: false,
+      googleicons: false,
+      npm: false,
+    },
     families: [
       {
         name: 'Commit Mono',


### PR DESCRIPTION
## Summary

- disable unused Nuxt Fonts network providers
- keep Commit Mono resolved through the local provider only
- remove Bunny and Fontshare catalog requests from clean builds

## Verification

- `pnpm build`, with zero remote font provider requests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm cf:types:check`

Authored and verified by Codex.