### PR TITLE
fix: apply Commit Mono sitewide

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -3,7 +3,7 @@
 @source "../../../content/**/*";
 
 @theme {
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-sans: "Commit Mono", ui-monospace, monospace;
   --font-mono: "Commit Mono", ui-monospace, monospace;
 }
 
@@ -45,6 +45,7 @@ body {
   background-attachment: fixed;
   color: var(--ui-text);
   font-family: var(--font-sans);
+  font-size-adjust: from-font;
   text-rendering: optimizeLegibility;
 }
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Commit Mono only reached code and OG images, so the homepage looked unchanged. Use it as the site font and keep fallback text stable while it loads.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).