### PR TITLE
fix: resolve content pages served with a trailing slash

### DIFF
--- a/app/composables/useContentPage.ts
+++ b/app/composables/useContentPage.ts
@@ -1,11 +1,11 @@
 import type { MaybeRefOrGetter } from 'vue'
 import type { SitePage } from '#shared/types'
 import { toValue } from 'vue'
-import { resolveContentPage } from '../utils/content-page'
+import { contentPageKey, resolveContentPage } from '../utils/content-page'
 
 export function useContentPage(path: MaybeRefOrGetter<string>) {
   return useAsyncData(
-    () => `page:${toValue(path)}`,
+    () => contentPageKey(toValue(path)),
     () => {
       const pagePath = toValue(path)
       return resolveContentPage(

--- a/app/middleware/content.global.ts
+++ b/app/middleware/content.global.ts
@@ -1,5 +1,7 @@
+import { normalizeContentPath } from '~/utils/content-page'
+
 export default defineNuxtRouteMiddleware(async (to) => {
-  if (to.path === '/experimental')
+  if (normalizeContentPath(to.path) === '/experimental')
     return
 
   const { data } = await useContentPage(to.path)

--- a/app/utils/content-page.ts
+++ b/app/utils/content-page.ts
@@ -6,9 +6,30 @@ export type ContentPageResult
 
 type QueryPage = (path: string) => Promise<SitePage | null>
 
+/**
+ * Content documents are stored without a trailing slash, and every prerendered
+ * payload is keyed from that bare path. Cloudflare still serves the directory
+ * form, so `/blog/post/` hydrates with the key `page:/blog/post/`, misses the
+ * prerendered `page:/blog/post` entry, queries a path no document owns, and
+ * renders a fatal 404 from `[...all].vue`.
+ */
+export function normalizeContentPath(path: string): string {
+  const withoutTrailingSlash = path.replace(/\/+$/, '')
+  return withoutTrailingSlash || '/'
+}
+
+/**
+ * The payload cache key and the content query share one normalization, so a
+ * route form can never resolve to a key the prerender did not write.
+ */
+export function contentPageKey(path: string): string {
+  return `page:${normalizeContentPath(path)}`
+}
+
 export async function resolveContentPage(path: string, queryPage: QueryPage): Promise<ContentPageResult> {
-  const page = await queryPage(path)
+  const contentPath = normalizeContentPath(path)
+  const page = await queryPage(contentPath)
   return page
     ? { _tag: 'Ok', page, styles: [] }
-    : { _tag: 'NotFound', path }
+    : { _tag: 'NotFound', path: contentPath }
 }

--- a/test/unit/content-page.test.ts
+++ b/test/unit/content-page.test.ts
@@ -1,7 +1,52 @@
 import { describe, expect, it, vi } from 'vitest'
-import { resolveContentPage } from '../../app/utils/content-page'
+import { contentPageKey, normalizeContentPath, resolveContentPage } from '../../app/utils/content-page'
+
+describe('normalizeContentPath', () => {
+  it.each([
+    ['/blog/my-open-source-journey/', '/blog/my-open-source-journey'],
+    ['/blog/', '/blog'],
+    ['/projects/', '/projects'],
+    ['/experimental/', '/experimental'],
+    ['/blog', '/blog'],
+    ['/', '/'],
+    ['//', '/'],
+  ])('maps %s to %s', (path, expected) => {
+    expect(normalizeContentPath(path)).toBe(expected)
+  })
+})
+
+describe('contentPageKey', () => {
+  it('gives a trailing-slash route the key of its prerendered payload', () => {
+    expect(contentPageKey('/blog/my-open-source-journey/')).toBe(contentPageKey('/blog/my-open-source-journey'))
+  })
+
+  it('keeps the root route distinct', () => {
+    expect(contentPageKey('/')).toBe('page:/')
+  })
+})
 
 describe('resolveContentPage', () => {
+  it('queries the trailing-slash route against the stored content path', async () => {
+    const page = { path: '/blog/my-open-source-journey' }
+    const query = vi.fn().mockImplementation(async (path: string) => path === '/blog/my-open-source-journey' ? page : null)
+
+    await expect(resolveContentPage('/blog/my-open-source-journey/', query)).resolves.toEqual({
+      _tag: 'Ok',
+      page,
+      styles: [],
+    })
+    expect(query).toHaveBeenCalledWith('/blog/my-open-source-journey')
+  })
+
+  it('reports the normalized path when nothing matches', async () => {
+    const query = vi.fn().mockResolvedValue(null)
+
+    await expect(resolveContentPage('/missing/', query)).resolves.toEqual({
+      _tag: 'NotFound',
+      path: '/missing',
+    })
+  })
+
   it('keeps the direct Comark document unchanged', async () => {
     const page = {
       body: {

--- a/test/unit/use-content-page.test.ts
+++ b/test/unit/use-content-page.test.ts
@@ -36,4 +36,34 @@ describe('useContentPage', () => {
 
     expect(queriedPaths).toEqual(['/projects', '/blog'])
   })
+
+  it('resolves a trailing-slash route against the prerendered payload key', async () => {
+    const queriedPaths: string[] = []
+    let dataKey!: MaybeRefOrGetter<string>
+    let query!: () => Promise<unknown>
+
+    vi.stubGlobal('useAsyncData', (key: MaybeRefOrGetter<string>, handler: () => Promise<unknown>) => {
+      dataKey = key
+      query = handler
+      return {}
+    })
+    vi.stubGlobal('queryCollection', () => ({
+      path: (pagePath: string) => ({
+        first: async () => {
+          queriedPaths.push(pagePath)
+          return pagePath === '/blog/my-open-source-journey' ? { path: pagePath } : null
+        },
+      }),
+    }))
+
+    useContentPage(() => '/blog/my-open-source-journey/')
+    expect(toValue(dataKey)).toBe('page:/blog/my-open-source-journey')
+
+    await expect(query()).resolves.toEqual({
+      _tag: 'Ok',
+      page: { path: '/blog/my-open-source-journey' },
+      styles: [],
+    })
+    expect(queriedPaths).toEqual(['/blog/my-open-source-journey'])
+  })
 })


### PR DESCRIPTION
### Description

Hitting `/blog/my-open-source-journey/` renders the 404 page. The trailing slash
lands in the `useAsyncData` key, so the page asks for `page:/blog/my-open-source-journey/`
while the prerender wrote `page:/blog/my-open-source-journey`. Payload misses,
the handler re-runs in the browser, `queryCollection('pages').path('/blog/my-open-source-journey/')`
matches no document, and `[...all].vue` throws a fatal 404.

Sentry HARLANZW-COM-1 logged 217 of these on the live site, plus seven more issues
across preview hosts. Every event shows the same breadcrumb pair: a 200 from
`/<path>/_payload.json`, then a navigation from `/<path>/` to `/<path>`.

`contentPageKey()` and `resolveContentPage()` now share one `normalizeContentPath()`,
so the cache key and the content query cannot drift from each other again.

Two things I did not chase:

- `getBreadcrumbs(route.path)` in `[...all].vue` still gets the raw path. A trailing
  slash there yields an empty trailing crumb. Cosmetic, no Sentry issue, left alone.
- `filterExpectedClientError` in `shared/sentry.ts` drops every fatal 404 before it
  reaches Sentry. That is why these stopped appearing after #29 even though the bug
  was still live. It is the right call for genuine 404s, but it does mean a
  regression here goes unreported. Worth a think, not in this PR.

### Additional context

The three `InvalidStateError: Failed to execute 'postMessage' on 'BroadcastChannel'`
issues in the same batch are downstream of this one. `nuxt-skew-protection`'s
multi-tab plugin closes its channel on `app:error`, then the manifest poll posts to
it five minutes later. `skewProtection.multiTab: false` in #29 already stops that
locally; the upstream plugin still has the ordering bug.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).