### PR TITLE
chore: adopt the shared eslint base config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,28 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm peers check
-      - run: pnpm lint
+      # ESLint's cache entry is keyed on hash(eslintVersion + nodeVersion +
+      # stringify(config)). `stringify` cannot serialize rule *implementations*, so
+      # a new eslint-plugin-harlanzw build would not invalidate the entries and the
+      # run could report stale green. The key covers every input that can change a
+      # verdict without changing the serialized config.
+      - name: Restore eslint cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .eslintcache
+          key: eslint-${{ runner.os }}-${{ hashFiles('eslint.config.js', 'pnpm-lock.yaml', 'package.json') }}-${{ github.sha }}
+          restore-keys: |
+            eslint-${{ runner.os }}-${{ hashFiles('eslint.config.js', 'pnpm-lock.yaml', 'package.json') }}-
+      # `lint:ci` is `eslint .` plus `--cache --cache-strategy content`. Measured
+      # on this repo: ~2.6s uncached, ~1.9s warm. `--cache-strategy content` is
+      # MANDATORY here, because the default `metadata` strategy keys on
+      # mtime+size and checkout gives every file a fresh mtime, so it would
+      # invalidate the whole cache every run and buy nothing.
+      #
+      # `--concurrency auto` is deliberately absent: at 79 linted files it is
+      # slower than serial (~3.6s vs ~2.6s), the thread pool costing more than
+      # it saves.
+      - run: pnpm lint:ci
       - run: pnpm typecheck
       - run: pnpm exec playwright-core install --with-deps chromium
       - run: pnpm test:run

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .vscode
 coverage
 *.tsbuildinfo
+.eslintcache
 .nuxt
 .nitro
 .cache

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,12 @@
 import antfu from '@antfu/eslint-config'
-import harlanzw from 'eslint-plugin-harlanzw'
+import { harlanzw } from 'eslint-plugin-harlanzw'
 
-export default antfu({
-  ignores: [
-    '.data/**',
-    'content/**',
-    'worker-configuration.d.ts',
-  ],
-  rules: {
-    'node/prefer-global/buffer': 'off',
-    'node/prefer-global/process': 'off',
-  },
-}, ...harlanzw())
+export default antfu(
+  {},
+  // `base` carries the shared ignore set and node-globals overrides that used to
+  // be inlined here. `.data/**` and `worker-configuration.d.ts` come from that
+  // set; `content/**` is repo specific, so it goes through `ignores`.
+  ...harlanzw({
+    base: { type: 'app', ignores: ['content/**'] },
+  }),
+)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "preview": "wrangler dev",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
+    "lint:ci": "eslint . --cache --cache-strategy content",
     "lint:fix": "eslint . --fix",
     "typecheck": "nuxt typecheck",
     "test": "vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.18.0
+      version: 0.18.0
     feed:
       specifier: ^6.0.0
       version: 6.0.0
@@ -269,7 +269,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       nuxt:
         specifier: 'catalog:'
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.1)))(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.1))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.12.5)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
@@ -4423,8 +4423,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.18.0:
+    resolution: {integrity: sha512-SX83tlR7KMCeovEWsTqMY4uUCCcaFk7zM15GuEcBWSzteqYv4Fq9ojDxlLTieO4A+5uj1O+uL6UzHzWgsBcpIw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -11985,7 +11985,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.18.0
-      version: 0.18.0
+      specifier: ^0.20.0
+      version: 0.20.0
     feed:
       specifier: ^6.0.0
       version: 6.0.0
@@ -269,7 +269,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.20.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       nuxt:
         specifier: 'catalog:'
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.1)))(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260813.1)(@opentelemetry/api@1.9.1))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.12.5)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
@@ -4423,8 +4423,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.18.0:
-    resolution: {integrity: sha512-SX83tlR7KMCeovEWsTqMY4uUCCcaFk7zM15GuEcBWSzteqYv4Fq9ojDxlLTieO4A+5uj1O+uL6UzHzWgsBcpIw==}
+  eslint-plugin-harlanzw@0.20.0:
+    resolution: {integrity: sha512-ZhF9pTlsfJ5Bn+8GKpq8o2j0IB23uSLPQDl8VAr859esrI3unTnZXKEzlFQH3/zKsuB4XrZcbQxtEA1inmZguQ==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -11985,7 +11985,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.20.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ minimumReleaseAgeExclude:
   - '@harlan-zw/nuxt-cloudflare@0.0.14 || 0.0.18'
   - '@harlan-zw/comark-content@0.0.7 || 0.0.8 || 0.0.9 || 0.0.12 || 0.0.15 || 0.0.17'
   - miniflare@5.20260811.0-alpha
+  - eslint-plugin-harlanzw@0.18.0
 shamefullyHoist: true
 autoInstallPeers: false
 shellEmulator: true
@@ -81,7 +82,7 @@ catalog:
   cheerio: ^1.2.0
   consola: ^3.4.2
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.18.0
   feed: ^6.0.0
   # Nitro 2 requires H3 1. Keep its app types ahead of module-local H3 2.
   h3: ^1.15.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ minimumReleaseAgeExclude:
   - '@harlan-zw/nuxt-cloudflare@0.0.14 || 0.0.18'
   - '@harlan-zw/comark-content@0.0.7 || 0.0.8 || 0.0.9 || 0.0.12 || 0.0.15 || 0.0.17'
   - miniflare@5.20260811.0-alpha
-  - eslint-plugin-harlanzw@0.18.0
+  - eslint-plugin-harlanzw@0.20.0
 shamefullyHoist: true
 autoInstallPeers: false
 shellEmulator: true
@@ -82,7 +82,7 @@ catalog:
   cheerio: ^1.2.0
   consola: ^3.4.2
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.18.0
+  eslint-plugin-harlanzw: ^0.20.0
   feed: ^6.0.0
   # Nitro 2 requires H3 1. Keep its app types ahead of module-local H3 2.
   h3: ^1.15.11


### PR DESCRIPTION
### Description

`eslint.config.js` was carrying the ignore list and the two `node/prefer-global/*`
overrides by hand, which is exactly the copy-paste that `base()` in
eslint-plugin-harlanzw 0.19.2 exists to absorb. `.data/**` and
`worker-configuration.d.ts` now come from the shared set. `content/**` is specific
to this repo, so it goes through the `ignores` option.

Resolved config is equivalent. Same 79 files linted before and after, zero
messages either way, and `content/**` stays fully unlinted (`eslint content` still
exits with "all of the files matching the glob pattern content are ignored", and
each markdown file passed explicitly reports "File ignored because of a matching
ignore pattern"). `content/**` stays root anchored on purpose: `**/content/**`
would also swallow the 17 files under `app/components/content/`.

Three severity changes for a source file, measured with `eslint --print-config`
against `origin/main`: `ts/no-use-before-define` error to off, plus
`harlanzw/prefer-satisfies` and `harlanzw/nuxt-no-redundant-component-imports`
arriving at `warn` from the version bump. Neither new rule fires here. Test files
pick up two more from base's test block, `no-console` and
`ts/no-unsafe-function-type` going error to off.

CI lint moves to a new `lint:ci` script with `--cache --cache-strategy content`
behind an `actions/cache` restore, same shape as nuxtseo.com. Roughly 2.6s to
1.9s on an idle machine. A re-check on a loaded machine kept the same ordering,
with the warm cache about 2.5x faster than a cold run. `--concurrency auto` is
deliberately left out: at 79 files it measured slower than serial, and the re-check
agreed. `pnpm lint` stays uncached so a local run after editing a rule
implementation cannot report stale green.

### Additional context

An earlier revision of this branch pinned 0.18.0, where `base()` put `CLAUDE.md`,
`AGENTS.md`, `.claude/**`, and `.cursor/**` in a global `ignores` block. Flat
config global ignores win over any later `files` match, so the prompt rules could
never see those files even though the comment above the block said the prompt
configs linted them. 0.19.2 fixes it with a `base()` option, `agentFiles: 'ignore'
| 'lint'`, and `harlanzw()` passes `lint` whenever its prompt config is on. The
same release also made the shared ignore globs recursive, `playground/**` to
`**/playground/**` and so on, for monorepos with nested copies.

This repo is unaffected either way. Nothing agent-shaped is tracked, `git ls-files`
finds no `CLAUDE.md` or `AGENTS.md`, and `.claude` is already in `.gitignore`, so
prompt detection stays off and no `harlanzw/prompt-*` key appears in the resolved
config. Verified with a throwaway `CLAUDE.md` in the tree, then deleted: 0.19.2
lints it and reports `harlanzw/prompt-weak-instruction`, matching `main`, where
0.18.0 reported "File ignored because of a matching ignore pattern". No repo
workaround was needed, so none was added or removed. `pnpm lint`, `pnpm typecheck`,
and the unit suite all pass.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).



