### PR TITLE
fix: dead links, gone-page redirects, sitemap trailing-slash canonical

### DIFF
--- a/app/components/content/Tweet.vue
+++ b/app/components/content/Tweet.vue
@@ -1,9 +1,19 @@
 <script setup lang="ts">
 import type { TweetResult } from '#shared/types'
 
-const { id } = defineProps<{ id: string }>()
-const { data, error, status } = await useFetch<TweetResult>(() => `/api/get-tweet/${id}`)
-const tweetUrl = computed(() => `https://x.com/i/status/${id}`)
+const { id: rawId } = defineProps<{ id: string }>()
+/**
+ * comark-content's renderer coerces any bare attribute value that looks like
+ * a JSON number through `JSON.parse`, regardless of how it was quoted in the
+ * markdown source. Tweet snowflake IDs are 18-19 digits, well past
+ * `Number.MAX_SAFE_INTEGER`, so that round-trip silently rounds the last few
+ * digits and the id stops matching any real tweet. A real snowflake ID never
+ * starts with `0`, so authors prefix the id with one in content (`id="0175…"`)
+ * to dodge the numeric-looking regex and keep it a string; strip it back off here.
+ */
+const id = computed(() => rawId.replace(/^0/, ''))
+const { data, error, status } = await useFetch<TweetResult>(() => `/api/get-tweet/${id.value}`)
+const tweetUrl = computed(() => `https://x.com/i/status/${id.value}`)
 const formattedDate = computed(() => data.value?._tag === 'Ok'
   ? new Intl.DateTimeFormat('en-AU', { dateStyle: 'medium' }).format(new Date(data.value.tweet.createdAt))
   : '')

--- a/content/blog/6.2023-july.md
+++ b/content/blog/6.2023-july.md
@@ -41,20 +41,20 @@ That's why I was excited for the start of July. I had an entire week free in Syd
 
 With this excitement, I naively announced that I'd get something out every day on Twitter.
 
-:Tweet{id="1675466770029879298"}
+:Tweet{id="01675466770029879298"}
 
 The v2 release of Nuxt SEO Kit has been something bouncing around in my mind for many months, so I decided to focus on that.
 
 It started off really fun with overwhelmingly positive feedback. I even received my first Pizza sponsorship.
-An extra special shout out to [Omar McPizza](https://twitter.com/McPizza0)
+An extra special shout out to Omar McPizza
 
-:Tweet{id="1676178825603076096"}
+:Tweet{id="01676178825603076096"}
 
 Each night I was staying up progressively later and later. By the Friday release at 7am, I was done.
 
 I had burnt the candle at both ends and was ready to enjoy the weekend.
 
-:Tweet{id="1677574499078930432"}
+:Tweet{id="01677574499078930432"}
 
 I wasn't able to get Nuxt SEO Kit v2 out, but I was happy with what I had achieved.
 

--- a/content/blog/ai-in-open-source.md
+++ b/content/blog/ai-in-open-source.md
@@ -30,8 +30,8 @@ I don't want to add to it. [Daniel Roe's post on using AI in open source](https:
 
 ### Sites I own
 
-- The [PR owner agent](https://github.com/harlan-zw/harlan-agent-kit/blob/main/harlan-agent-kit/skills/pr-owner/SKILL.md) watches the deployment and runs relevant smoke tests against production.
-- Agents may [repair post-merge CI](https://github.com/harlan-zw/harlan-agent-kit/blob/main/harlan-agent-kit/skills/pr-owner/SKILL.md) on the default branch.
+- The [PR owner agent](https://github.com/harlan-zw/harlan-agent-kit/blob/main/harlan-agent-kit/skills/take-ownership/SKILL.md) watches the deployment and runs relevant smoke tests against production.
+- Agents may [repair post-merge CI](https://github.com/harlan-zw/harlan-agent-kit/blob/main/harlan-agent-kit/skills/take-ownership/SKILL.md) on the default branch.
 
 ## Workflow: Issue Triaging
 

--- a/content/blog/how-the-heck-does-vite-work.md
+++ b/content/blog/how-the-heck-does-vite-work.md
@@ -62,12 +62,12 @@ The main functional difference you'll notice with Vite and your webpack app, is 
 Don't worry if the below terms don't make sense to you, we'll be exploring them below.
 
 ### webpack (Nuxt.js / Vue CLI / etc)
-- Supported Modules: [ES Modules](https://www.2ality.com/2014/09/es6-modules-final.html), [CommonJS](http://wiki.commonjs.org/) and [AMD Modules](https://github.com/amdjs/amdjs-api/wiki/AMD)
+- Supported Modules: [ES Modules](https://web.archive.org/web/20260511134339/https://2ality.com/2014/09/es6-modules-final.html), [CommonJS](http://wiki.commonjs.org/) and [AMD Modules](https://github.com/amdjs/amdjs-api/wiki/AMD)
 - Dev Server: Bundled modules served via webpack-dev-server using [Express.js](https://expressjs.com/) web server
 - Production Build: webpack
 
 ### Vite
-- Supported Modules: [ES Modules](https://www.2ality.com/2014/09/es6-modules-final.html)
+- Supported Modules: [ES Modules](https://web.archive.org/web/20260511134339/https://2ality.com/2014/09/es6-modules-final.html)
 - Dev Server: Native-ES-Modules, served via Vite using a [Koa](https://github.com/koajs/koa) web server
 - Production build: [Rollup](https://github.com/rollup/rollup)
 

--- a/content/blog/nuxt-3-migration-cheatsheet.md
+++ b/content/blog/nuxt-3-migration-cheatsheet.md
@@ -37,7 +37,7 @@ Let's do this!
 
 - [Nuxt 3 - Docs](https://nuxt.com/docs/getting-started/introduction)
 - [Nuxt 3 - Official Migration Guide](https://nuxt.com/docs/migration/overview)
-- [Nuxt 3 - Migration guide discussion](https://github.com/nuxt/framework/discussions/3989)
+- Nuxt 3 - Migration guide discussion (removed, `nuxt/framework` discussions were retired after the Nuxt 3 merge into `nuxt/nuxt`)
 - [Vue 3 - Migration Guide](https://v3-migration.vuejs.org/)
 
 **Tech**
@@ -49,7 +49,7 @@ Let's do this!
 **Nuxt 3 Examples**
 
 - [Nuxt Examples](https://nuxt.com/docs/examples/essentials/hello-world) - Minimal scoped examples
-- [NuxtBnB](https://github.com/MasteringNuxt/NuxtBnB) - Complex app
+- [NuxtBnB](https://web.archive.org/web/20230106223315/https://github.com/MasteringNuxt/NuxtBnB) - Complex app (repo removed; archived snapshot)
 - [Nuxt Movies](https://github.com/nuxt/movies) - Complex app
 - [harlanzw.com](https://github.com/harlan-zw/harlanzw.com) - @nuxt/content app
 
@@ -61,7 +61,7 @@ Let's do this!
 ### Getting help
 
 - [Discord](https://discord.com/invite/ps2h6QT): create a post in `#nuxt3-help` if you get stuck
-- [Twitter Nuxt Community](https://twitter.com/i/communities/1498235047194808320)
+- Twitter Nuxt Community (removed, the community no longer exists)
 - Post on StackOverflow with the tag [Nuxt](https://stackoverflow.com/questions/tagged/nuxt), [kissu](https://stackoverflow.com/users/8816585/kissu) may help you if you're lucky
 - [Reddit Nuxt.js](https://www.reddit.com/r/nuxtjs/)
 
@@ -458,7 +458,7 @@ It's best practice to use the [$fetch / useFetch](https://nuxt.com/docs/migratio
 
 If are determined to use `$http` you can use [nuxt-alt/http](https://github.com/nuxt-alt/http).
 
-See the [Nuxt 3 and Axios](https://github.com/nuxt/framework/discussions/4514) discussion for additional context.
+See the Nuxt 3 and Axios discussion for additional context (removed, `nuxt/framework` discussions were retired after the Nuxt 3 merge into `nuxt/nuxt`).
 ::
 
 ::checkbox
@@ -597,7 +597,7 @@ const { $moment } = useNuxtApp()
 I'd recommend using [nuxt-icon](https://github.com/nuxt-modules/icon).
 
 Alternatively,
-see the [Using FontAwesome in Nuxt 3](https://github.com/nuxt/framework/discussions/3823) discussion for plugin code sample.
+see the Using FontAwesome in Nuxt 3 discussion for plugin code sample (removed, `nuxt/framework` discussions were retired after the Nuxt 3 merge into `nuxt/nuxt`).
 
 #### @nuxtjs/dayjs
 
@@ -605,7 +605,7 @@ See [Nuxt3 support](https://github.com/nuxt-community/dayjs-module/issues/376) f
 
 #### @nuxtjs/toast
 
-See [Examples of using the @nuxtjs/toast or any vue toast plugin?](https://github.com/nuxt/framework/discussions/2732) discussion for plugin code sample.
+See the Examples of using the @nuxtjs/toast or any vue toast plugin? discussion for plugin code sample (removed, `nuxt/framework` discussions were retired after the Nuxt 3 merge into `nuxt/nuxt`).
 
 #### @nuxtjs/gtm
 

--- a/content/blog/scale-your-vue-components.md
+++ b/content/blog/scale-your-vue-components.md
@@ -383,7 +383,7 @@ Using a package like [Storybook](https://storybook.js.org/) is a great idea, but
 As a starting point, you can create pages under a `/demo` prefix and throw your components on it.
 You want an easy way to find components and classes that are available.
 
-Here is a rough demo page as an example: [Massive Monster UI Demo](https://massivemonster.co/demo). Keep it as basic as you want.
+Here is a rough demo page as an example: [Massive Monster](https://massivemonster.co) (the original demo page is gone). Keep it as basic as you want.
 
 ![Massive Monster Demo Page](/blog/brand-demo.png){width="939" height="464"}
 

--- a/content/blog/vue-use-head-v1.md
+++ b/content/blog/vue-use-head-v1.md
@@ -55,7 +55,7 @@ So my full attention went into performance ([e1bc8d2](https://github.com/vueuse/
 
 ## Why a major bump?
 
-While most issues were closed and easy to solve, there was a major outstanding issue that I wanted to address, *Server Only Tags* (see [discussion](https://github.com/nuxt/framework/discussions/7785)).
+While most issues were closed and easy to solve, there was a major outstanding issue that I wanted to address, *Server Only Tags* (removed, `nuxt/framework` discussions were retired after the Nuxt 3 merge into `nuxt/nuxt`).
 There was also a nasty issue with tags disappearing unexpectedly when hydrating.
 
 Both of these were blocked by how the DOM patching was designed. The old strategy was to add state to the DOM and use this
@@ -111,7 +111,7 @@ So Unhead was born. It has first-party support for Vue, but there is planned wor
 @vueuse/head v1 is now a thin wrapper for unhead, while being fully backwards compatible.
 
 There are too many enhancements and feature improvements to mention here, check the below release notes or jump straight
-to the [docs](https://unhead.harlanzw.com).
+to the [docs](https://unhead.unjs.io).
 
 I'm excited about this new package, and I hope you are too! I'll be writing a dedicated blog post about it soon.
 
@@ -128,12 +128,12 @@ Featuring:
 
 ### ✨ Enhancements
 
-- Vue 2.7 Support  ([docs](https://unhead.harlanzw.com/integrations/vue/setup))
-- Options API Support ([docs](https://unhead.harlanzw.com/integrations/vue/options-api))
+- Vue 2.7 Support  ([docs](https://unhead.unjs.io))
+- Options API Support ([docs](https://unhead.unjs.io))
 
 #### htmlAttrs / bodyAttrs merging
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/handling-duplicates#tagduplicatestrategy)
+[Documentation](https://unhead.unjs.io)
 
 Now merged by default instead of replace.
 
@@ -154,7 +154,7 @@ useHead({
 
 #### Array / Object Classes
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/class-attr)
+[Documentation](https://unhead.unjs.io)
 
 When using the htmlAttrs or bodyAttrs options, you can use the class attribute to add classes to the html or body elements.
 
@@ -175,7 +175,7 @@ useHead({
 
 #### Better deduping
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/handling-duplicates#using-arrays-with-meta)
+[Documentation](https://unhead.unjs.io)
 
 Tag deduping is now vastly improved. It's likely you won't need `key` anymore.
 
@@ -213,7 +213,7 @@ useHead({
 
 #### useServerHead
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/server-only-tags)
+[Documentation](https://unhead.unjs.io)
 
 Lets you render tags on the server only. This has the same API as `useHead`.
 
@@ -230,7 +230,7 @@ useServerHead({
 
 #### useSeoMeta
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/useseometa)
+[Documentation](https://unhead.unjs.io)
 
 Define meta tags in a flat object, fully typed.
 
@@ -246,7 +246,7 @@ useSeoMeta({
 
 #### tagPosition
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/positions)
+[Documentation](https://unhead.unjs.io)
 
 Lets you define the position of a tag in the DOM.
 
@@ -263,7 +263,7 @@ useHead({
 
 #### tagPriority
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/sorting)
+[Documentation](https://unhead.unjs.io)
 
 Lets you define the priority of a tag with a number or string.
 
@@ -284,11 +284,11 @@ useHead({
 
 #### tagDuplicateStrategy
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/handling-duplicates#tagduplicatestrategy)
+[Documentation](https://unhead.unjs.io)
 
 #### DOM Event Handlers
 
-[Documentation](https://unhead.harlanzw.com/guide/guides/dom-event-handling)
+[Documentation](https://unhead.unjs.io)
 
 Function support for DOM event handlers.
 
@@ -315,7 +315,7 @@ useHead({
 Engine is now powered by hooks, provided by [hookable](https://github.com/unjs/hookable). This allows you to hook into
 any of the core functionality.
 
-See [API hooks](https://unhead.harlanzw.com/api/core/create-head) and [Infer SEO MetaTags](https://unhead.harlanzw.com/guide/recipes/infer-seo-meta-tags), not documented properly yet.
+See [API hooks](https://unhead.unjs.io) and [Infer SEO MetaTags](https://unhead.unjs.io), not documented properly yet.
 
 #### New shortcut composables
 
@@ -338,7 +338,7 @@ Same API as `useHead`, but targeted as a specific tag type.
 
 Please report any issues you find and they will fixed be promptly.
 
-You may consider using [@unhead/vue](https://unhead.harlanzw.com/integrations/vue/setup) directly if you [don't need @vueuse/head](https://unhead.harlanzw.com/integrations/vue/vueuse-head).
+You may consider using [@unhead/vue](https://unhead.unjs.io) directly if you [don't need @vueuse/head](https://unhead.unjs.io).
 
 ### Verify your tags
 
@@ -382,7 +382,7 @@ useHead({
 // <html class="my-class new-class">
 ```
 
-Check the [documentation](https://unhead.harlanzw.com/guide/guides/handling-duplicates#tagduplicatestrategy) to learn more.
+Check the [documentation](https://unhead.unjs.io) to learn more.
 
 ### Duplicate tags in `useHead`
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -84,6 +84,11 @@ export default defineNuxtConfig({
     url: site.url,
     description: site.description,
     defaultLocale: site.language,
+    // Cloudflare serves prerendered content pages from their directory form
+    // (`/blog/` not `/blog`), 307-redirecting the bare path. Sitemap entries
+    // and canonical tags need to point at that final URL directly, or Google
+    // sees a redirect hop instead of a self-referencing canonical.
+    trailingSlash: true,
   },
 
   ui: {
@@ -243,6 +248,11 @@ export default defineNuxtConfig({
       },
     },
     '/api/**': { prerender: false, robots: false },
+    // `/hire` and `/meet` were removed in the Nuxt v4 rewrite with no direct
+    // replacement; redirect to the homepage rather than leave them 404ing
+    // for the traffic and backlinks that still land on them.
+    '/hire': { redirect: { to: '/', statusCode: 301 } },
+    '/meet': { redirect: { to: '/', statusCode: 301 } },
     '/sponsors': { prerender: false },
     '/experimental': { prerender: false, robots: false, streaming: true },
   },


### PR DESCRIPTION
An agent wrote this PR (mcp-dogfood skill run, worktree `mcp-dogfood/run-1`) — it resolves the 5 open Nuxt SEO Pro tickets for harlanzw.com by working through the live Pro MCP.

## Fixes

- **`Tweet.vue` / `6.2023-july.md`** — real bug in `@harlan-zw/comark-content`'s renderer: it `JSON.parse()`s any bare numeric-looking attribute value, and Twitter snowflake IDs (18-19 digits) exceed `Number.MAX_SAFE_INTEGER`, so the id silently rounds before use. Fixed by prefixing ids with a leading zero in content (a real snowflake id never starts with `0`) and stripping it back off in the component.
- **`nuxt.config.ts` — `site.trailingSlash: true`** — Cloudflare serves prerendered pages from their directory form (`/blog/`, not `/blog`), 307-redirecting the bare path. Sitemap entries and canonical tags need to point at the final URL directly. Confirmed live before this fix: `/blog/`'s own `<link rel=canonical>` pointed at the redirecting `/blog`.
- **`nuxt.config.ts` — 301s for `/hire` and `/meet`** — both intentionally removed in the 2026-08-10 Nuxt v4 rewrite with no replacement authored, both still earning clicks/backlinks.
- **Blog content** — dead external links replaced or removed: retired `nuxt/framework` GitHub discussions (merged into `nuxt/nuxt`), the dead `unhead.harlanzw.com` subdomain (now `unhead.unjs.io`), dead Twitter profiles/community links, a removed demo page, a 2ality.com slug only reachable via web.archive.org.
- One remaining ticket (6 stale 404s with zero internal referrers, no matching route/history) was correctly dismissed via `dismiss_action` rather than force-fixed.

## Review note

The worker's own diff also picked up a batch of unrelated copyedits while running eslint against files it touched — this repo's `harlanzw/ai-deslop-*` rules flag pre-existing prose issues (casing, filler phrases, exclamation marks) across the whole file, not just changed lines, and the worker "fixed" several of those in passing, including one edit that broke a sentence's grammar. All of that was reverted before this commit; every remaining hunk is a genuine link/redirect/config fix tied to one of the 5 tickets.

## Not independently verified

Couldn't run a live `nuxi dev`/`build` in this worktree (symlinked `node_modules` is missing `@harlan-zw/nuxt-sentry`, pre-existing env issue). Config shapes were checked by hand against the installed `nitropack`/`nuxt-site-config` type defs and source, and the trailing-slash/canonical diagnosis was confirmed against the live site (`curl -I`, canonical tag) before the fix, not after.