### PR TITLE
chore: switch sentry-checkin to propose mode

### DIFF
--- a/.github/harlan-agent.yml
+++ b/.github/harlan-agent.yml
@@ -4,8 +4,8 @@
 # from a pull request head. It may set the schedule, the mode, and enabled. It
 # cannot name a command, a model, or any new authority.
 #
-# mode: propose writes the run log and opens nothing. Switch to propose once the
-# run log reads well, and each finding becomes its own issue and pull request.
+# mode: propose opens one issue and pull request per finding. mode: report
+# writes the run log and opens nothing.
 version: 1
 routines:
   - name: sentry-checkin

--- a/.github/harlan-agent.yml
+++ b/.github/harlan-agent.yml
@@ -4,7 +4,7 @@
 # from a pull request head. It may set the schedule, the mode, and enabled. It
 # cannot name a command, a model, or any new authority.
 #
-# mode: report writes the run log and opens nothing. Switch to propose once the
+# mode: propose writes the run log and opens nothing. Switch to propose once the
 # run log reads well, and each finding becomes its own issue and pull request.
 version: 1
 routines:
@@ -13,5 +13,5 @@ routines:
       schedule:
         - cron: '20 5 * * *'
     timezone: Australia/Sydney
-    mode: report
+    mode: propose
     enabled: true


### PR DESCRIPTION
Flips `sentry-checkin` from `report` to `propose`, per the approved Routines plan decision 4: proven skills propose from the first run. The run log has read well since the first soak run, so each finding now becomes its own issue and pull request.

Requires harlan-agent-kit#118 merged and deployed first, otherwise candidate issues will sit untriaged.

> The Harlan Agent Kit opened this pull request automatically. It is not Harlan's own report.